### PR TITLE
Fix teminal characters for the side border lines

### DIFF
--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -98,7 +98,7 @@ function Terminal:create_buf(name, do_border, height, width)
         -- ## Border start ##
         local border_lines = { '┌' .. string.rep('─', width) .. '┐' }
         for _ = 1, height do
-          table.insert(border_lines, '|' .. string.rep(' ', width) .. '|')
+          table.insert(border_lines, '│' .. string.rep(' ', width) .. '│')
         end
         table.insert(border_lines, '└' .. string.rep('─', width) .. '┘')
         -- ## Border end ##


### PR DESCRIPTION
On my system, each character on the left/right border has a small space between them, so I replaced the existing character with a character that I also use for indent lines and it solved the issue.

I see in the screenshot provided that the border on the left hand side and right hand side should be solid and not broken.

Not sure if its a difference in systems but this change fixes it on my end and now the terminal looks like it does in the provided screenshot.

Please review and if it looks good with you we can merge this fix in