### PR TITLE
feat: use nvim_open_win native border

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Requirements
 
--   Neovim Nightly
+-   Neovim Nightly (0.5)
 
 ### Install
 
@@ -58,15 +58,9 @@ require'FTerm'.setup({
         row = 0.5,
         col = 0.5
     }
-    -- Default border characters, you can customize them individually
-    border = {
-        horizontal = '─',
-        vertical = '|',
-        topLeft = '┌',
-        topRight = '┐',
-        bottomRight = '┘',
-        bottomLeft = '└'
-    }
+    -- Neovim's native `nvim_open_win` border config
+    -- :h nvim_open_win
+    border = 'single' -- or { "╔", "═" ,"╗", "║", "╝", "═", "╚", "║" }
 })
 
 -- Keybinding


### PR DESCRIPTION
With https://github.com/neovim/neovim/pull/13998 merged in the neovim's core. We now have native borders in a floating window. Which will remove the need for an extra floating window + buffer for creating the border and makes the opening/closing terminal faster.