### PR TITLE
Set filetype just after the window is created

### DIFF
--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -93,6 +93,7 @@ function Terminal:create_win(buf, opts)
     local win_handle = api.nvim_open_win(buf, true, opts)
 
     api.nvim_win_set_option(win_handle, "winhl", "Normal:Normal")
+    api.nvim_buf_set_option(buf, "filetype", "FTerm")
 
     return win_handle
 end


### PR DESCRIPTION
See #13

Set in `create_win()` instead of `create_buf()` because window options
such as `winhl`, `winblend` should be available after the window is
created.