### PR TITLE
separate autocmd for separate terminals

### DIFF
--- a/lua/FTerm/config.lua
+++ b/lua/FTerm/config.lua
@@ -26,4 +26,13 @@ function U.create_config(opts)
     }
 end
 
+function U.to_hex(str)
+    return str:gsub(
+        ".",
+        function(c)
+            return string.format("%02X", string.byte(c))
+        end
+    )
+end
+
 return U


### PR DESCRIPTION
Currently, `VimResized` and `TermClose` only work for one terminal at a time and for the custom terminal, it is just broken.

This PR hopes to fix that issue.