### PR TITLE
Interface for sending commands to terminal

### DIFF
--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -14,6 +14,7 @@ function Terminal:new()
         win = nil,
         buf = nil,
         terminal = nil,
+        jobid = nil,
     }
 
     self.__index = self
@@ -131,6 +132,7 @@ function Terminal:term()
 
         -- IDK what to do with this now, maybe later we can use it
         self.terminal = pid
+        self.jobid = vim.b.terminal_job_id
 
         -- Need to setup different TermClose autocmd for different terminal instances
         -- Otherwise this will be overriden by other terminal aka custom terminal
@@ -181,6 +183,7 @@ function Terminal:close(force)
 
         self.buf = nil
         self.terminal = nil
+        self.jobid = nil
     end
 
     self:restore_cursor()
@@ -194,6 +197,12 @@ function Terminal:toggle()
     else
         self:close()
     end
+end
+
+-- Terminal:run is used to (open and) run commands to terminal window
+function Terminal:run(command)
+    self:open()
+    api.nvim_chan_send(self.jobid, command)
 end
 
 return Terminal

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -150,16 +150,23 @@ end
 
 -- Terminal:open does all the magic of opening terminal
 function Terminal:open()
-    self:remember_cursor()
 
-    local buf = self:create_buf()
+    -- Create new window and terminal if it doesn't exist
+    if not vim.tbl_contains(vim.api.nvim_list_wins(), self.win) then
+        self:remember_cursor()
 
-    local win = self:create_win(buf)
+        local buf = self:create_buf()
+        local win = self:create_win(buf)
 
-    self:term()
+        self:term()
 
-    -- Need to store the handles after opening the terminal
-    self:store(win, buf)
+        -- Need to store the handles after opening the terminal
+        self:store(win, buf)
+
+    else
+        -- move to right window
+        vim.api.nvim_set_current_win(self.wim)
+    end
 end
 
 -- Terminal:close does all the magic of closing terminal and clearing the buffers/windows


### PR DESCRIPTION
Thanks for this project. Awesome to see what neovim can do these days with a little lua code.

I played around and I noticed that sending commands to running terminals was lacking.
Think e.g. having a Python REPL which you want to send commands to like:
```lua
require 'FTerm.terminal':new():setup( cmd = "ipython" ):run("%run "..vim.fn.expand("%").."\n")
```

Current implementaiton can not be used for this, as it neither supports persisting the shell after a comand is run, nor allow sending commands to already running terminals.

It was easy enough to add this, so I made a patch for my own use.
If this feature is of interested to you, I am open for discussing implementation details.