### PR TITLE
feat: `auto_close`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Options can be provided when calling `setup()`.
 
 > NOTE: This is not meant for edit in the default terminal. See [custom terminal](#custom-terminal) section for use case.
 
+-   `border`: Neovim's native window border (default: `single`). See `:h nvim_open_win` for more configuration options.
+
+-   `close_on_kill`: Kill the terminal buffer as soon as shell exists (default: `true`)
+
 -   `dimensions`: Object containing the terminal window dimensions.
 
     The value for each field should be between `0` and `1`
@@ -61,8 +65,6 @@ Options can be provided when calling `setup()`.
     -   `width` - Width of the terminal window (default: `0.8`)
     -   `x` - X axis of the terminal window (default: `0.5`)
     -   `y` - Y axis of the terminal window (default: `0.5`)
-
--   `border`: Neovim's native window border (default: `single`). See `:h nvim_open_win` for more configuration options.
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Options can be provided when calling `setup()`.
 
 -   `border`: Neovim's native window border (default: `single`). See `:h nvim_open_win` for more configuration options.
 
--   `close_on_kill`: Kill the terminal buffer as soon as shell exists (default: `true`)
+-   `auto_close`: Close the terminal as soon as shell/command exits (default: `true`). Disabling this will mimic the native terminal behaviour.
 
 -   `dimensions`: Object containing the terminal window dimensions.
 

--- a/lua/FTerm/config.lua
+++ b/lua/FTerm/config.lua
@@ -25,8 +25,7 @@ function U.create_config(opts)
         cmd = opts.cmd or O.cmd,
         dimensions = opts.dimensions and vim.tbl_extend('keep', opts.dimensions, O.dimensions) or O.dimensions,
         border = opts.border or O.border,
-        -- Also treat `nil` as false
-        close_on_kill = opts.close_on_kill and O.close_on_kill or false,
+        close_on_kill = opts.close_on_kill ~= false,
     }
 end
 

--- a/lua/FTerm/config.lua
+++ b/lua/FTerm/config.lua
@@ -5,6 +5,8 @@ local O = {
     cmd = os.getenv('SHELL'),
     -- Neovim's native `nvim_open_win` border config
     border = 'single',
+    -- Kill the terminal buffer as soon as shell exists
+    close_on_kill = true,
     -- Dimensions are treated as percentage
     dimensions = {
         height = 0.8,
@@ -23,6 +25,8 @@ function U.create_config(opts)
         cmd = opts.cmd or O.cmd,
         dimensions = opts.dimensions and vim.tbl_extend('keep', opts.dimensions, O.dimensions) or O.dimensions,
         border = opts.border or O.border,
+        -- Also treat `nil` as false
+        close_on_kill = opts.close_on_kill and O.close_on_kill or false,
     }
 end
 

--- a/lua/FTerm/config.lua
+++ b/lua/FTerm/config.lua
@@ -5,8 +5,8 @@ local O = {
     cmd = os.getenv('SHELL'),
     -- Neovim's native `nvim_open_win` border config
     border = 'single',
-    -- Kill the terminal buffer as soon as shell exists
-    close_on_kill = true,
+    -- Close the terminal as soon as shell/command exits
+    auto_close = true,
     -- Dimensions are treated as percentage
     dimensions = {
         height = 0.8,
@@ -25,7 +25,7 @@ function U.create_config(opts)
         cmd = opts.cmd or O.cmd,
         dimensions = opts.dimensions and vim.tbl_extend('keep', opts.dimensions, O.dimensions) or O.dimensions,
         border = opts.border or O.border,
-        close_on_kill = opts.close_on_kill ~= false,
+        auto_close = opts.auto_close ~= false,
     }
 end
 

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -211,7 +211,7 @@ end
 
 -- Terminal:toggle is used to toggle the terminal window
 function Terminal:toggle()
-    -- If window is stored then it is already opened
+    -- If window is stored and valid then it is already opened, then close it
     if utils.is_win_valid(self.win) then
         self:close()
     else

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -149,9 +149,12 @@ function Terminal:term()
             self:close(true)
         end
 
-        -- This fires when someone executes `exit` inside term
-        -- So, in this case the buffer should also be removed instead of reusing
-        cmd("autocmd! TermClose <buffer> lua require('FTerm.terminal').au_close['" .. self.au_key .. "']()")
+        -- Only close the terminal buffer when `close_on_kill` is true
+        if self.config.close_on_kill then
+            -- This fires when someone executes `exit` inside term
+            -- So, in this case the buffer should also be removed instead of reusing
+            cmd("autocmd! TermClose <buffer> lua require('FTerm.terminal').au_close['" .. self.au_key .. "']()")
+        end
     end
 
     cmd('startinsert')

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -143,14 +143,14 @@ function Terminal:term()
         -- https://github.com/numToStr/FTerm.nvim/pull/27/files#r674020429
         self.tjob_id = vim.b.terminal_job_id
 
-        -- Need to setup different TermClose autocmd for different terminal instances
-        -- Otherwise this will be overriden by other terminal aka custom terminal
-        Terminal.au_close[self.au_key] = function()
-            self:close(true)
-        end
-
         -- Only close the terminal buffer when `close_on_kill` is true
         if self.config.close_on_kill then
+            -- Need to setup different TermClose autocmd for different terminal instances
+            -- Otherwise this will be overriden by other terminal aka custom terminal
+            Terminal.au_close[self.au_key] = function()
+                self:close(true)
+            end
+
             -- This fires when someone executes `exit` inside term
             -- So, in this case the buffer should also be removed instead of reusing
             cmd("autocmd! TermClose <buffer> lua require('FTerm.terminal').au_close['" .. self.au_key .. "']()")

--- a/lua/FTerm/utils.lua
+++ b/lua/FTerm/utils.lua
@@ -1,0 +1,11 @@
+local u = {}
+
+function u.is_win_valid(win)
+    return win and vim.api.nvim_win_is_valid(win)
+end
+
+function u.is_buf_valid(buf)
+    return buf and vim.api.nvim_buf_is_loaded(buf)
+end
+
+return u


### PR DESCRIPTION
By default, FTerm closes the terminal buffer as soon as the shell or command exists and there is no way to override this behavior.

This PR provides an option i.e. `auto_close` to override that behavior and prevents buffer from closing. FWIW this is also the neovim's default behavior for terminals.

Fixes #18 