### PR TITLE
adding fix for ensuring fterm filetype is set

### DIFF
--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -96,10 +96,6 @@ function Terminal:create_win(buf)
 
     api.nvim_win_set_option(win, 'winhl', 'Normal:Normal')
 
-    -- Setting filetype in `create_win()` instead of `create_buf()` because window options
-    -- such as `winhl`, `winblend` should be available after the window is created.
-    api.nvim_buf_set_option(buf, 'filetype', 'FTerm')
-
     return win
 end
 

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -110,6 +110,7 @@ function Terminal:term()
         -- This function fails if the current buffer is modified (all buffer contents are destroyed).
         local pid = fn.termopen(self.config.cmd)
 
+
         -- IDK what to do with this now, maybe later we can use it
         self.terminal = pid
 
@@ -133,6 +134,9 @@ function Terminal:term()
             cmd(string.format("autocmd! TermClose <buffer> lua require('FTerm.terminal').au_close['%s']()", key))
         end
     end
+
+    -- This prevents the filetype being changed to term instead of fterm
+    api.nvim_buf_set_option(self.buf, 'filetype', 'FTerm')
 
     cmd('startinsert')
 

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -76,8 +76,11 @@ function Terminal:create_buf()
     if utils.is_buf_valid(prev) then
         return prev
     end
+    local buf = api.nvim_create_buf(false, true)
+    -- this ensures filetype is set to Fterm on first run
+    api.nvim_buf_set_option(buf, 'filetype', 'FTerm')
 
-    return api.nvim_create_buf(false, true)
+    return buf
 end
 
 -- Terminal:create_win creates a new window with a given buffer
@@ -95,6 +98,7 @@ function Terminal:create_win(buf)
     })
 
     api.nvim_win_set_option(win, 'winhl', 'Normal:Normal')
+
 
     return win
 end
@@ -131,7 +135,7 @@ function Terminal:term()
         end
     end
 
-    -- This prevents the filetype being changed to term instead of fterm
+    -- This prevents the filetype being changed to term instead of fterm when closing the floating window
     api.nvim_buf_set_option(self.buf, 'filetype', 'FTerm')
 
     cmd('startinsert')

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -110,7 +110,6 @@ function Terminal:term()
         -- This function fails if the current buffer is modified (all buffer contents are destroyed).
         local pid = fn.termopen(self.config.cmd)
 
-
         -- IDK what to do with this now, maybe later we can use it
         self.terminal = pid
 


### PR DESCRIPTION
this fixes this issue here: https://github.com/beauwilliams/focus.nvim/issues/49

I found sometimes the filetype changes from fterm to term.