### PR TITLE
Do not set options when self.buf is nil

### DIFF
--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -153,7 +153,9 @@ function Term:open_term()
     end
 
     -- This prevents the filetype being changed to term instead of fterm when closing the floating window
-    A.nvim_buf_set_option(self.buf, 'filetype', self.config.ft)
+    if self.buf then
+      A.nvim_buf_set_option(self.buf, 'filetype', self.config.ft)
+    end
 
     cmd('startinsert')
 


### PR DESCRIPTION
https://github.com/neovim/neovim/issues/14090#issuecomment-1004318147

Now the master did breaking changes to several functions fail with `nil`
value. This patch makes it execute only when self.buf is not `nil`.