### PR TITLE
docs(readme): fix type

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Following options can be provided when calling [`setup()`](#setup). Below is the
     dimensions = {
         height = 0.8, -- Height of the terminal window
         width = 0.8, -- Width of the terminal window
-        x = 0.5 -- X axis of the terminal window
-        y = 0.5 -- Y axis of the terminal window
-    }
+        x = 0.5, -- X axis of the terminal window
+        y = 0.5, -- Y axis of the terminal window
+    },
 
     -- Callback invoked when the terminal exits.
     -- See `:h jobstart-options`


### PR DESCRIPTION
Trying to copy and paste configuration get some lua error.  better fix that.