### PR TITLE
feat: allow `on_open` to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Following options can be provided when calling [`setup()`](#setup). Below is the
         y = 0.5, -- Y axis of the terminal window
     },
 
+    ---Callback invoked when the terminal opens.
+    ---@type fun()|nil
+    on_open = nil,
+
     ---Callback invoked when the terminal exits.
     ---See `:h jobstart-options`
     ---@type fun()|nil

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -152,6 +152,10 @@ function Term:open_term()
     -- This prevents the filetype being changed to `term` instead of `FTerm` when closing the floating window
     A.nvim_buf_set_option(self.buf, 'filetype', self.config.ft)
 
+    if self.config.on_open then
+        self.config.on_open(self)
+    end
+
     return self:prompt()
 end
 

--- a/lua/FTerm/utils.lua
+++ b/lua/FTerm/utils.lua
@@ -15,6 +15,7 @@ local U = {}
 ---@field auto_close boolean: Close the terminal as soon as command exits (default: `true`)
 ---@field hl string: Highlight group for the terminal buffer (default: `true`)
 ---@field blend number: Transparency of the floating window (default: `true`)
+---@field on_open function: Callback invoked when the terminal opens (default: `nil`)
 ---@field on_exit function: Callback invoked when the terminal exits (default: `nil`)
 ---@field on_stdout function: Callback invoked when the terminal emits stdout data (default: `nil`)
 ---@field on_stderr function: Callback invoked when the terminal emits stderr data (default: `nil`)


### PR DESCRIPTION
Hello! Wanting to see if it’s possible to merge in these changes to add the ability for users to define an `on_open` callback that will be executed when a terminal is first opened.

Example use case:

When using [lazygit](https://github.com/jesseduffield/lazygit), normally you can press `q` to quit or `<Esc>` to “go back” after doing something like staging individual lines in a separate window. I only want these keymaps to apply to the specific buffer/terminal that was created for lazygit though (since I have `<Esc>` mapped to `<C-\\><C-n>` normally). Having this `on_open` callback will allow me to define these once the terminal and buffer/window are created and only apply it to that buffer since I will have access to the terminal instance as the first parameter and can get the buf number for it.

Here’s an example configuration of the above scenario:

```lua

local Term = require 'FTerm'
local lazygit = Term:new {
    cmd = ‘lazygit’,
    border = 'rounded',
    dimensions = {
        height = 0.9,
        width = 0.9,
    },
    on_open = function(term)
        vim.api.nvim_buf_set_keymap(
            term.buf,
            'n',
            'q',
            '<Cmd>close<CR>',
            { noremap = true, silent = true }
        )
        vim.api.nvim_buf_set_keymap(
            term.buf,
            't',
            '<Esc>',
            '<Esc>',
            { noremap = true, silent = true }
        )
    end,
}
```