### PR TITLE
fix(window): make sure last_win is valid before setting current window

### DIFF
--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -66,7 +66,7 @@ function Term:restore_cursor()
             cmd(('silent! %s wincmd w'):format(self.prev_win))
         end
 
-        if A.nvim_win_is_valid(self.last_win) then
+        if U.is_win_valid(self.last_win) then
             A.nvim_set_current_win(self.last_win)
             A.nvim_win_set_cursor(self.last_win, self.last_pos)
         end

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -66,8 +66,10 @@ function Term:restore_cursor()
             cmd(('silent! %s wincmd w'):format(self.prev_win))
         end
 
-        A.nvim_set_current_win(self.last_win)
-        A.nvim_win_set_cursor(self.last_win, self.last_pos)
+        if A.nvim_win_is_valid(self.last_win) then
+            A.nvim_set_current_win(self.last_win)
+            A.nvim_win_set_cursor(self.last_win, self.last_pos)
+        end
 
         self.last_win = nil
         self.prev_win = nil


### PR DESCRIPTION
This prevents nvim from throwing "Invalid window ID" error when fterm gets opened and the window which it was opened on (last_win) gets closed (e.g. nvim-tree).

To reproduce the bug, set view.float.enable to `true` in nvim-tree's config. Then open nvim-tree and open a terminal instance while nvim-tree is the current window. Now if you toggle the terminal, you'll get an error saying "Invalid window ID" because nvim-tree has already closed its own window due to another floating window being opened on top of it.