### PR TITLE
feat: add clear_env and env to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Following options can be provided when calling [`setup()`](#setup). Below is the
         y = 0.5, -- Y axis of the terminal window
     },
 
+    ---Replace instead of extend the current environment with `env`.
+    ---See `:h jobstart-options`
+    ---@type boolean
+    clear_env = false,
+
+    ---Map of environment variables extending the current environment.
+    ---See `:h jobstart-options`
+    ---@type table<string,string>|nil
+    env = nil,
+
     ---Callback invoked when the terminal exits.
     ---See `:h jobstart-options`
     ---@type fun()|nil

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -144,6 +144,8 @@ end
 function Term:open_term()
     -- NOTE: `termopen` will fails if the current buffer is modified
     self.terminal = fn.termopen(U.is_cmd(self.config.cmd), {
+        clear_env = self.config.clear_env,
+        env = self.config.env,
         on_stdout = self.config.on_stdout,
         on_stderr = self.config.on_stderr,
         on_exit = function(...)

--- a/lua/FTerm/utils.lua
+++ b/lua/FTerm/utils.lua
@@ -15,6 +15,8 @@ local U = {}
 ---@field auto_close boolean: Close the terminal as soon as command exits (default: `true`)
 ---@field hl string: Highlight group for the terminal buffer (default: `true`)
 ---@field blend number: Transparency of the floating window (default: `true`)
+---@field clear_env boolean: Replace instead of extend the current environment with `env` (default: `false`)
+---@field env table: Map of environment variables extending the current environment (default: `nil`)
 ---@field on_exit function: Callback invoked when the terminal exits (default: `nil`)
 ---@field on_stdout function: Callback invoked when the terminal emits stdout data (default: `nil`)
 ---@field on_stderr function: Callback invoked when the terminal emits stderr data (default: `nil`)
@@ -33,6 +35,7 @@ U.defaults = {
     auto_close = true,
     hl = 'Normal',
     blend = 0,
+    clear_env = false,
     dimensions = {
         height = 0.8,
         width = 0.8,


### PR DESCRIPTION
Thought it'd be useful to support this. Personally I use this to set `$EDITOR` to `string.format('nvim --server %s --remote-tab', vim.v.servername)`.