### PR TITLE
feat(config): add on_attach option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Following options can be provided when calling [`setup()`](#setup). Below is the
     ---@type table<string,string>|nil
     env = nil,
 
+    ---Callback invoked when the terminal buffer is created
+    ---@type fun(term: Term, bufnr: number)|nil
+    on_attach = nil,
+
     ---Callback invoked when the terminal exits.
     ---See `:h jobstart-options`
     ---@type fun()|nil

--- a/lua/FTerm/terminal.lua
+++ b/lua/FTerm/terminal.lua
@@ -90,6 +90,9 @@ function Term:create_buf()
     end
 
     local buf = A.nvim_create_buf(false, true)
+    if self.config.on_attach then
+        self.config.on_attach(self, buf)
+    end
 
     -- this ensures filetype is set to Fterm on first run
     A.nvim_buf_set_option(buf, 'filetype', self.config.ft)

--- a/lua/FTerm/utils.lua
+++ b/lua/FTerm/utils.lua
@@ -17,6 +17,7 @@ local U = {}
 ---@field blend number: Transparency of the floating window (default: `true`)
 ---@field clear_env boolean: Replace instead of extend the current environment with `env` (default: `false`)
 ---@field env table: Map of environment variables extending the current environment (default: `nil`)
+---@field on_attach function: Callback invoked when the terminal buffer is created (default: `nil`)
 ---@field on_exit function: Callback invoked when the terminal exits (default: `nil`)
 ---@field on_stdout function: Callback invoked when the terminal emits stdout data (default: `nil`)
 ---@field on_stderr function: Callback invoked when the terminal emits stderr data (default: `nil`)


### PR DESCRIPTION
So I wanted to add some keymaps to the terminal's buffer, and saw an `on_attach` option was missing in the config.

I'm not quite certain whether `on_attach` fits in this context since it is called after buffer is created and not after the terminal process is attached to the buffer. Even so I decided to name it this way so that users can easily figure out what the callback does.

**NOTE**: Passing `Term` alongside buffer handler is useful for actions like `toggle`.