### PR TITLE
fix: The `auto_close` configuration of scratch is not working

### DIFF
--- a/lua/FTerm/init.lua
+++ b/lua/FTerm/init.lua
@@ -59,8 +59,6 @@ function M.scratch(cfg)
         return vim.notify('FTerm: Please provide configuration for scratch terminal', vim.log.levels.ERROR)
     end
 
-    cfg.auto_close = false
-
     M:new(cfg):open()
 end
 


### PR DESCRIPTION
This line of code causes the custom configuration not to work