### PR TITLE
Respect value of auto_close in FTerm.scratch

### DIFF
--- a/lua/FTerm/init.lua
+++ b/lua/FTerm/init.lua
@@ -59,7 +59,9 @@ function M.scratch(cfg)
         return vim.notify('FTerm: Please provide configuration for scratch terminal', vim.log.levels.ERROR)
     end
 
-    cfg.auto_close = false
+    if cfg.auto_close == nil then
+      cfg.auto_close = false
+    end
 
     M:new(cfg):open()
 end


### PR DESCRIPTION
`FTerm.scratch` currently ignores an explicit `auto_close = true`.

Resolves #88